### PR TITLE
Add keep-alive workflow to maintain repository activity

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,27 @@
+name: Keep Alive
+
+on:
+  schedule:
+    - cron: '0 0 1 * *' # 每月 1 號午夜執行，確保 repo 保持活躍
+  workflow_dispatch:
+
+jobs:
+  keep-alive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Update keep-alive timestamp
+        run: |
+          echo "Last keep-alive: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" > .github/keep-alive.txt
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/keep-alive.txt
+          git diff --staged --quiet || git commit -m "chore: keep workflows alive [skip ci]"
+          git push


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically maintains repository activity by updating a timestamp file on a monthly schedule. This helps prevent the repository from being marked as inactive or archived due to lack of recent commits.

## Key Changes
- Added `.github/workflows/keep-alive.yml` workflow that:
  - Runs on the 1st of every month at midnight UTC via cron schedule
  - Can also be triggered manually via `workflow_dispatch`
  - Updates `.github/keep-alive.txt` with the current UTC timestamp
  - Commits and pushes the change using the GitHub Actions bot account
  - Uses `[skip ci]` flag to prevent triggering other workflows

## Implementation Details
- The workflow uses `ubuntu-latest` runner with minimal permissions (only `contents: write`)
- Git configuration is set to use the GitHub Actions bot identity for commits
- The `git diff --staged --quiet` check ensures a commit is only created if there are actual changes
- The timestamp is recorded in UTC format for consistency across timezones

https://claude.ai/code/session_01A9Hqofjpt1ZW4iPbeP8oyS